### PR TITLE
added row variance cut to ballgown script and new cutoff option

### DIFF
--- a/lib/kb_ballgown/core/ballgown_util.py
+++ b/lib/kb_ballgown/core/ballgown_util.py
@@ -385,7 +385,8 @@ class BallgownUtil:
                      '--sample_dir_group_table', sample_dir_group_table_file,
                      '--output_dir', ballgown_output_dir,
                      '--output_csvfile', output_csv,
-                     '--volcano_plot_file', volcano_plot_file
+                     '--volcano_plot_file', volcano_plot_file,
+                     '--variance_cutoff', 1 
                      ]
         rcmd_str = " ".join(str(x) for x in rcmd_list)
         log("rcmd_string is {0}".format(rcmd_str))

--- a/ui/narrative/methods/run_ballgown_app/spec.json
+++ b/ui/narrative/methods/run_ballgown_app/spec.json
@@ -40,24 +40,9 @@
       "checked_value": 1,
       "unchecked_value": 0
     }
-  },{
-    "id" : "condition",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text"
   }],
-  "parameter-groups": [
-      {
-        "id": "condition_pair_subset",
-        "parameters": ["condition"],
-        "optional": true,
-        "allow_multiple": true,
-        "with_border": true
-      }
-  ],
-  "behavior" : {
+ "parameter-groups": [],
+ "behavior" : {
     "service-mapping" : {
       "url" : "",
       "name" : "kb_ballgown",
@@ -83,11 +68,8 @@
         {
           "input_parameter" : "run_all_combinations",
           "target_property" : "run_all_combinations"
-        },
-        {
-          "input_parameter" : "condition_pair_subset",
-          "target_property" : "condition_pair_subset"
-        }],
+        }
+      ],
       "output_mapping" : [
         {
           "service_method_output_path": [0, "result_directory"],


### PR DESCRIPTION
Okay this new version of the R script contains the new row variance cut code.   Its been tested on the data that was discussed in PTV-799 and PTV-809.   I recommend that the script now be invoked with the --variance_cutoff 1    
option by default.     The numeric value the actual variance threshold and doesn't need to be 1, but 1 is a decent choice.    If the option isn't given the script should behave exactly as before.  (backwards compatible)